### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ dependencies:
   - pip
   - pip:
     - --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-    - jax[cuda11_cudnn82]==0.4.8
+    - jax[cuda11]
     - optax==0.1.4
     - memory_efficient_attention==0.1.3
     - flax==0.6.8
@@ -19,4 +19,5 @@ dependencies:
     - diffusers==0.20.0
     - lpips_jax==0.1.0
     - ipython==8.17.2
-    - opencv-python==4.8.1
+    - opencv-python==4.8.1.78
+    - ffmpegio


### PR DESCRIPTION
Old enviroment.yml would not build correctly i guess jax wheels locations have changed

ffmpeg was missing but is required for matfusion_diffusers_env_demo.ipynb

pip says opencv-python==4.8.1 doesnt exist but 4.8.1.78 works